### PR TITLE
Fixing check for validity of var

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,8 +38,8 @@
     name: "{{ backup_remote_host_name }}"
     key: "{{ backup_remote_host_name }} {{ backup_remote_host_key }}"
   when:
-    - backup_remote_host_name
-    - backup_remote_host_key
+    - backup_remote_host_name | length > 0
+    - backup_remote_host_key | length > 0
 
 - include: databases.yml
   when: backup_mysql


### PR DESCRIPTION
Adding check for validity of name and key of remote backup host. Until now this leads to an error if the server name contains an "-" char in the name.